### PR TITLE
State slices refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ fx.app({
     count: 0
   },
   actions: {
-    down: fx => fx.merge({ count: fx.get("count") - 1 }),
-    up: fx => fx.merge({ count: fx.get("count") + 1 })
+    down: ({ state, fx }) => fx.merge({ count: state.count - 1 }),
+    up: ({ state, fx }) => fx.merge({ count: state.count + 1 })
   },
-  view: fx => [
+  view: ({ state, fx }) => [
     "main",
-    ["h1", fx.get("count")],
+    ["h1", state.count],
     [
       "button",
       {
         onclick: fx.action("down"),
-        disabled: fx.get("count") <= 0
+        disabled: state.count <= 0
       },
       "-"
     ],

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import { isFn, assign } from "./utils";
+import { isFn, assign, get } from "./utils";
 import { makeFx } from "./fxUtils";
 import { patch } from "./patch";
 
@@ -15,10 +15,11 @@ export function app(props) {
       isFn(actions[key])
         ? (function(key, action) {
             actions[key] = function(data) {
-              var actionFx = assign(sliceFx.creators, {
-                data: data
+              var actionResult = action({
+                state: get(namespace, store.state),
+                data: data,
+                fx: sliceFx.creators
               });
-              var actionResult = action(actionFx);
               sliceFx.run(actionResult);
               return actionResult;
             };
@@ -35,7 +36,10 @@ export function app(props) {
   var rootFx = makeFx([], store, props.fx);
   var container = props.container || document.body;
   function render() {
-    var nextNode = props.view(rootFx.creators);
+    var nextNode = props.view({
+      state: store.state,
+      fx: rootFx.creators
+    });
     patch(nextNode, container, rootFx.run);
   }
 

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -4,7 +4,7 @@ test("throw for unknown action", () =>
   expect(() =>
     app({
       actions: {
-        foo: fx => fx.action("unknown")
+        foo: ({ fx }) => fx.action("unknown")
       }
     }).foo()
   ).toThrow("couldn't find action: unknown"));
@@ -13,7 +13,7 @@ test("throw for unknown slice action", () =>
   expect(() =>
     app({
       actions: {
-        foo: fx => fx.action("uh.oh")
+        foo: ({ fx }) => fx.action("uh.oh")
       }
     }).foo()
   ).toThrow("couldn't find action: uh.oh"));
@@ -24,10 +24,10 @@ test("run action fx", done => {
       value: 0
     },
     actions: {
-      foo: fx => fx.action("bar", { some: "data" }),
-      bar: fx => {
-        expect(fx.data).toEqual({ some: "data" });
-        expect(fx.get()).toEqual({ value: 0 });
+      foo: ({ fx }) => fx.action("bar", { some: "data" }),
+      bar: ({ state, data }) => {
+        expect(data).toEqual({ some: "data" });
+        expect(state).toEqual({ value: 0 });
         done();
       }
     }
@@ -48,17 +48,17 @@ test("run multiple action fx", done =>
       value: 0
     },
     actions: {
-      foo: fx => [
+      foo: ({ fx }) => [
         fx.action("bar", { some: "data" }),
         fx.action("baz", { other: "data" })
       ],
-      bar: fx => {
-        expect(fx.data).toEqual({ some: "data" });
-        expect(fx.get()).toEqual({ value: 0 });
+      bar: ({ state, data }) => {
+        expect(data).toEqual({ some: "data" });
+        expect(state).toEqual({ value: 0 });
       },
-      baz: fx => {
-        expect(fx.data).toEqual({ other: "data" });
-        expect(fx.get()).toEqual({ value: 0 });
+      baz: ({ state, data }) => {
+        expect(data).toEqual({ other: "data" });
+        expect(state).toEqual({ value: 0 });
         done();
       }
     }
@@ -67,10 +67,10 @@ test("run multiple action fx", done =>
 test("run slice action fx", done =>
   app({
     actions: {
-      foo: fx => fx.action("bar.baz", { some: "data" }),
+      foo: ({ fx }) => fx.action("bar.baz", { some: "data" }),
       bar: {
-        baz: fx => {
-          expect(fx.data).toEqual({ some: "data" });
+        baz: ({ data }) => {
+          expect(data).toEqual({ some: "data" });
           done();
         }
       }
@@ -82,12 +82,12 @@ test("run slice action fx outside of current namespace", done =>
     actions: {
       foo: {
         bar: {
-          baz: fx => fx.action(".fizz.buzz", { some: "data" })
+          baz: ({ fx }) => fx.action(".fizz.buzz", { some: "data" })
         }
       },
       fizz: {
-        buzz: fx => {
-          expect(fx.data).toEqual({ some: "data" });
+        buzz: ({ data }) => {
+          expect(data).toEqual({ some: "data" });
           done();
         }
       }

--- a/test/fx.test.js
+++ b/test/fx.test.js
@@ -25,7 +25,7 @@ test("allow adding new custom fx", () => {
     fx: [
       {
         name: "set",
-        creator: action => ["set", { action }],
+        creator: action => ({ action }),
         runner(props, getAction) {
           getAction(props.action)(externalState);
         }
@@ -35,9 +35,9 @@ test("allow adding new custom fx", () => {
       value: 0
     },
     actions: {
-      foo: fx => fx.set("set"),
-      set: fx => fx.merge(fx.data),
-      get: fx => fx.get()
+      foo: ({ fx }) => fx.set("set"),
+      set: ({ data, fx }) => fx.merge(data),
+      get: ({ state }) => state
     }
   });
 

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -6,18 +6,18 @@ test("merge can update state", () => {
       value: 0
     },
     actions: {
-      get: fx => fx.get(),
-      up: fx => {
-        expect(fx.get()).toEqual({ value: 0 });
-        expect(fx.data).toBe(2);
+      get: ({ state }) => state,
+      up: ({ state, data, fx }) => {
+        expect(state).toEqual({ value: 0 });
+        expect(data).toBe(2);
         return fx.merge({
-          value: fx.get("value") + fx.data
+          value: state.value + data
         });
       },
-      set: fx => {
-        expect(fx.get()).toEqual({ value: 2 });
-        expect(fx.data).toEqual({ merge: "properties" });
-        return fx.merge(fx.data);
+      set: ({ state, data, fx }) => {
+        expect(state).toEqual({ value: 2 });
+        expect(data).toEqual({ merge: "properties" });
+        return fx.merge(data);
       }
     }
   });

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -13,7 +13,7 @@ const state = {
   }
 };
 
-const get = fx => fx.get(fx.data);
+const get = ({ state }) => state;
 const makeApp = () =>
   app({
     state,
@@ -21,15 +21,15 @@ const makeApp = () =>
       get,
       foo: {
         get,
-        set: fx => fx.merge(fx.data.state, fx.data.path),
+        set: ({ data, fx }) => fx.merge(data.state, data.path),
         bar: {
           get,
           baz: {
             get,
-            eat: fx => {
-              expect(fx.get()).toEqual({ value: 1 });
-              expect(fx.data).toBe("banana");
-              return fx.merge({ food: fx.data });
+            eat: ({ state, data, fx }) => {
+              expect(state).toEqual({ value: 1 });
+              expect(data).toBe("banana");
+              return fx.merge({ food: data });
             }
           }
         }
@@ -43,30 +43,13 @@ const makeApp = () =>
 it("get state slices by default path", () => {
   const main = makeApp();
 
-  // get slices using default and path
   expect(main.get()).toEqual(state);
   expect(main.foo.get(null)).toEqual(state.foo);
   expect(main.foo.bar.get("")).toEqual(state.foo.bar);
   expect(main.foo.bar.baz.get(".")).toEqual(state.foo.bar.baz);
 });
 
-it("get state slices with custom path", () => {
-  const main = makeApp();
-
-  expect(main.get("foo")).toEqual(state.foo);
-  expect(main.get("foo.bar")).toEqual(state.foo.bar);
-  expect(main.get("foo.bar.baz")).toEqual(state.foo.bar.baz);
-});
-
-it("get state slices outside of current namespace", () => {
-  const main = makeApp();
-
-  // get other slice data with dot prefix
-  expect(main.foo.bar.baz.get(".fizz")).toEqual(state.fizz);
-  expect(main.foo.bar.baz.get(".fizz.buzz")).toEqual(state.fizz.buzz);
-});
-
-it("merge and get deeply nested state slices", () => {
+it("merge deeply nested state slices", () => {
   const main = makeApp();
 
   expect(main.foo.bar.baz.eat("banana")).toEqual([

--- a/test/view.test.js
+++ b/test/view.test.js
@@ -3,10 +3,10 @@ import { app } from "../src";
 test("attach fx to view", done => {
   app({
     actions: {
-      foo: fx => [fx.merge({ some: "value" }), fx.action("bar")],
+      foo: ({ fx }) => [fx.merge({ some: "value" }), fx.action("bar")],
       bar: () => done()
     },
-    view: fx => ["div", { onclick: fx.action("foo") }]
+    view: ({ fx }) => ["div", { onclick: fx.action("foo") }]
   });
   document.body.children[0].onclick();
 });


### PR DESCRIPTION
* bye `fx.get`
* still allow calling actions outside of slice
* use actions outside slice to manage state in the outside namespace